### PR TITLE
fix: handle UTF-8 surrogate encoding errors in chat conversion

### DIFF
--- a/samples/chat_with_surrogates.json
+++ b/samples/chat_with_surrogates.json
@@ -1,0 +1,36 @@
+{
+  "requesterUsername": "TestUser",
+  "responderUsername": "GitHub Copilot",
+  "requests": [
+    {
+      "message": {
+        "text": "Show me some braille art with a surrogate character: \udeaa here"
+      },
+      "response": [
+        {
+          "value": "Here is the art you requested with special chars: \udeaa\udead done!"
+        }
+      ],
+      "result": {
+        "timings": {
+          "totalElapsed": 1234
+        }
+      }
+    },
+    {
+      "message": {
+        "text": "Thanks, that looks great!"
+      },
+      "response": [
+        {
+          "value": "You're welcome! Let me know if you need anything else."
+        }
+      ],
+      "result": {
+        "timings": {
+          "totalElapsed": 567
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes #4 — chat_to_markdown.py crashes with UnicodeEncodeError: 'utf-8' codec can't encode character '\udeaa' when the exported chat JSON contains lone Unicode surrogates from braille/emoji art.

## Changes

### chat_to_markdown.py
- Added `sanitize_surrogates()` function that replaces lone surrogates (U+D800–U+DFFF) with the Unicode replacement character (U+FFFD)
- JSON file read now uses `errors='surrogatepass'` to allow surrogates through initial decode
- Raw text is sanitized before `json.loads()`
- Markdown output is sanitized before writing
- File write uses `errors='replace'` as a safety net

### samples/chat_with_surrogates.json
- Minimal synthetic test case with surrogate characters in both user message and assistant response
- No private/sensitive data — purely synthetic

## Validation

- ✅ Existing `samples/chat.json` → `samples/chat.md` converts successfully (no regression)
- ✅ New `samples/chat_with_surrogates.json` converts successfully (surrogates replaced with U+FFFD)
- ✅ No new output files left behind (cleaned up per contribution guide)